### PR TITLE
feat: implement MigrateQuery for MySQL and PostgreSQL dialects to han…

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -2,13 +2,60 @@ package rdsdata
 
 import (
 	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata/types"
 )
+
+var ordinalRegex = regexp.MustCompile(`\?`)
 
 // compile time type check
 var _ Dialect = (*DialectMySQL)(nil)
 
 // DialectMySQL is the MySQL dialect.
 type DialectMySQL struct{}
+
+// MigrateQuery converts a MySQL query into an RDS statement.
+func (d *DialectMySQL) MigrateQuery(query string, args []driver.NamedValue) (*rdsdata.ExecuteStatementInput, error) {
+	ordinal, err := isOrdinal(args)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ordinal {
+		params, err := convertNamedValues(args)
+		if err != nil {
+			return nil, err
+		}
+		return &rdsdata.ExecuteStatementInput{
+			Parameters: params,
+			Sql:        aws.String(query),
+		}, nil
+	}
+
+	// MySQL uses ? for placeholders, so we need to convert the ordinal placeholders to named placeholders.
+	namedArgs := convertOrdinalToNamed(args)
+	idx := 0
+	query = ordinalRegex.ReplaceAllStringFunc(query, func(string) string {
+		idx++
+		return ":" + strconv.Itoa(idx)
+	})
+
+	params, err := convertNamedValues(namedArgs)
+	if err != nil {
+		return nil, err
+	}
+	return &rdsdata.ExecuteStatementInput{
+		Parameters: params,
+		Sql:        aws.String(query),
+	}, nil
+}
 
 func (d *DialectMySQL) IsIsolationLevelSupported(level sql.IsolationLevel) bool {
 	switch level {
@@ -28,5 +75,34 @@ func (d *DialectMySQL) IsIsolationLevelSupported(level sql.IsolationLevel) bool 
 }
 
 func (d *DialectMySQL) GetFieldConverter(columnType string) FieldConverter {
+	switch strings.ToLower(columnType) {
+	case "bigint unsigned":
+		return func(field types.Field) (driver.Value, error) {
+			v, ok := field.(*types.FieldMemberLongValue)
+			if !ok {
+				return nil, fmt.Errorf("rdsdata: unexpected field type %T", field)
+			}
+			// go-sql-driver/mysql converts BIGINT UNSIGNED to uint64.
+			return uint64(v.Value), nil
+		}
+	case "decimal", "char", "varchar", "text", "enum":
+		return func(field types.Field) (driver.Value, error) {
+			v, ok := field.(*types.FieldMemberStringValue)
+			if !ok {
+				return nil, fmt.Errorf("rdsdata: unexpected field type %T", field)
+			}
+			// go-sql-driver/mysql converts these types to []byte.
+			return []byte(v.Value), nil
+		}
+	case "float":
+		return func(field types.Field) (driver.Value, error) {
+			v, ok := field.(*types.FieldMemberDoubleValue)
+			if !ok {
+				return nil, fmt.Errorf("rdsdata: unexpected field type %T", field)
+			}
+			// go-sql-driver/mysql converts FLOAT to float32.
+			return float32(v.Value), nil
+		}
+	}
 	return convertDefault
 }

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -1,12 +1,55 @@
 package rdsdata
 
-import "database/sql"
+import (
+	"database/sql"
+	"database/sql/driver"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
+)
+
+var postgresRegex = regexp.MustCompile(`\$([0-9]+)`)
 
 // compile time type check
 var _ Dialect = (*DialectPostgres)(nil)
 
 // DialectPostgres is the PostgreSQL dialect.
 type DialectPostgres struct{}
+
+// MigrateQuery converts a PostgreSQL query into an RDS statement.
+func (d *DialectPostgres) MigrateQuery(query string, args []driver.NamedValue) (*rdsdata.ExecuteStatementInput, error) {
+	ordinal, err := isOrdinal(args)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ordinal {
+		params, err := convertNamedValues(args)
+		if err != nil {
+			return nil, err
+		}
+		return &rdsdata.ExecuteStatementInput{
+			Parameters: params,
+			Sql:        aws.String(query),
+		}, nil
+	}
+
+	// PostgreSQL uses $1, $2, etc. for placeholders, so we need to convert the ordinal placeholders to named placeholders.
+	namedArgs := convertOrdinalToNamed(args)
+	query = postgresRegex.ReplaceAllStringFunc(query, func(s string) string {
+		return ":" + s[1:]
+	})
+
+	params, err := convertNamedValues(namedArgs)
+	if err != nil {
+		return nil, err
+	}
+	return &rdsdata.ExecuteStatementInput{
+		Parameters: params,
+		Sql:        aws.String(query),
+	}, nil
+}
 
 func (d *DialectPostgres) IsIsolationLevelSupported(level sql.IsolationLevel) bool {
 	switch level {


### PR DESCRIPTION
…dle named and ordinal parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced MySQL and PostgreSQL database interaction with improved query migration capabilities.
  - Added support for converting ordinal placeholders in SQL queries.

- **Bug Fixes**
  - Improved handling of various database field types and parameter processing.

- **Tests**
  - Expanded test coverage for MySQL data type handling with new functions for parameter and result conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->