### PR TITLE
feat: add support for DATETIME field type in MySQL dialect and corres…

### DIFF
--- a/_integration/mysql_test.go
+++ b/_integration/mysql_test.go
@@ -994,6 +994,32 @@ func TestMySQL_ConvertResult(t *testing.T) {
 		})
 	})
 
+	t.Run("TIME", func(t *testing.T) {
+		runMySQLTest(t, func(ctx context.Context, t *testing.T, db *sql.DB) {
+			if _, err := db.ExecContext(ctx, "CREATE TABLE test (value TIME(6))"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.ExecContext(ctx, `INSERT INTO test (value) VALUES ('12:34:56.789012')`); err != nil {
+				t.Fatal(err)
+			}
+
+			row := db.QueryRowContext(ctx, "SELECT value FROM test")
+
+			var value any
+			if err := row.Scan(&value); err != nil {
+				t.Fatal(err)
+			}
+
+			tv, ok := value.([]byte)
+			if !ok {
+				t.Errorf("unexpected value: %T", value)
+			}
+			if !bytes.Equal(tv, []byte("12:34:56.789012")) {
+				t.Errorf("unexpected value: %q", value)
+			}
+		})
+	})
+
 	t.Run("DATETIME", func(t *testing.T) {
 		runMySQLTest(t, func(ctx context.Context, t *testing.T, db *sql.DB) {
 			if _, err := db.ExecContext(ctx, "CREATE TABLE test (value DATETIME(6))"); err != nil {

--- a/_integration/mysql_test.go
+++ b/_integration/mysql_test.go
@@ -1046,4 +1046,31 @@ func TestMySQL_ConvertResult(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("TIMESTAMP", func(t *testing.T) {
+		runMySQLTest(t, func(ctx context.Context, t *testing.T, db *sql.DB) {
+			if _, err := db.ExecContext(ctx, "CREATE TABLE test (value TIMESTAMP(6))"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.ExecContext(ctx, `INSERT INTO test (value) VALUES ('2038-01-19 03:14:07.999999')`); err != nil {
+				t.Fatal(err)
+			}
+
+			row := db.QueryRowContext(ctx, "SELECT value FROM test")
+
+			var value any
+			if err := row.Scan(&value); err != nil {
+				t.Fatal(err)
+			}
+
+			// go-sql-driver/mysql converts TIMESTAMP to time.Time if ParseTime=true.
+			tv, ok := value.(time.Time)
+			if !ok {
+				t.Errorf("unexpected value: %T", value)
+			}
+			if !tv.Equal(time.Date(2038, 1, 19, 3, 14, 7, 999_999_000, jst)) {
+				t.Errorf("unexpected value: %v", value)
+			}
+		})
+	})
 }

--- a/_integration/mysql_test.go
+++ b/_integration/mysql_test.go
@@ -1073,4 +1073,26 @@ func TestMySQL_ConvertResult(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("YEAR", func(t *testing.T) {
+		runMySQLTest(t, func(ctx context.Context, t *testing.T, db *sql.DB) {
+			if _, err := db.ExecContext(ctx, "CREATE TABLE test (value YEAR(4))"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.ExecContext(ctx, `INSERT INTO test (value) VALUES (2021)`); err != nil {
+				t.Fatal(err)
+			}
+
+			row := db.QueryRowContext(ctx, "SELECT value FROM test")
+
+			var value any
+			if err := row.Scan(&value); err != nil {
+				t.Fatal(err)
+			}
+
+			if value != int64(2021) {
+				t.Errorf("unexpected value: %v, %T", value, value)
+			}
+		})
+	})
 }

--- a/_integration/mysql_test.go
+++ b/_integration/mysql_test.go
@@ -967,6 +967,33 @@ func TestMySQL_ConvertResult(t *testing.T) {
 		})
 	})
 
+	t.Run("DATE", func(t *testing.T) {
+		runMySQLTest(t, func(ctx context.Context, t *testing.T, db *sql.DB) {
+			if _, err := db.ExecContext(ctx, "CREATE TABLE test (value DATE)"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.ExecContext(ctx, `INSERT INTO test (value) VALUES ('2025-01-04')`); err != nil {
+				t.Fatal(err)
+			}
+
+			row := db.QueryRowContext(ctx, "SELECT value FROM test")
+
+			var value any
+			if err := row.Scan(&value); err != nil {
+				t.Fatal(err)
+			}
+
+			// go-sql-driver/mysql converts DATETIME to time.Time if ParseTime=true.
+			tv, ok := value.(time.Time)
+			if !ok {
+				t.Errorf("unexpected value: %T", value)
+			}
+			if !tv.Equal(time.Date(2025, 01, 04, 0, 0, 0, 0, jst)) {
+				t.Errorf("unexpected value: %q", value)
+			}
+		})
+	})
+
 	t.Run("DATETIME", func(t *testing.T) {
 		runMySQLTest(t, func(ctx context.Context, t *testing.T, db *sql.DB) {
 			if _, err := db.ExecContext(ctx, "CREATE TABLE test (value DATETIME(6))"); err != nil {

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -215,6 +215,18 @@ func (d *DialectMySQL) GetFieldConverter(columnType string) FieldConverter {
 				return nil, fmt.Errorf("rdsdata: unsupported field type: %T", v)
 			}
 		}
+
+	case "YEAR":
+		return func(field types.Field) (driver.Value, error) {
+			switch v := field.(type) {
+			case *types.FieldMemberStringValue:
+				return strconv.ParseInt(v.Value, 10, 64)
+			case *types.FieldMemberIsNull:
+				return nil, nil
+			default:
+				return nil, fmt.Errorf("rdsdata: unsupported field type: %T", v)
+			}
+		}
 	}
 	return convertMySQLDefault
 }

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -197,7 +197,7 @@ func (d *DialectMySQL) GetFieldConverter(columnType string) FieldConverter {
 			}
 		}
 
-	case "DATETIME":
+	case "DATETIME", "TIMESTAMP":
 		return func(field types.Field) (driver.Value, error) {
 			switch v := field.(type) {
 			case *types.FieldMemberStringValue:

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -178,6 +178,25 @@ func (d *DialectMySQL) GetFieldConverter(columnType string) FieldConverter {
 			}
 		}
 
+	case "DATE":
+		return func(field types.Field) (driver.Value, error) {
+			switch v := field.(type) {
+			case *types.FieldMemberStringValue:
+				if !d.parseTime {
+					return []byte(v.Value), nil
+				}
+				t, err := time.ParseInLocation("2006-01-02", v.Value, d.getLocation())
+				if err != nil {
+					return nil, err
+				}
+				return t, nil
+			case *types.FieldMemberIsNull:
+				return nil, nil
+			default:
+				return nil, fmt.Errorf("rdsdata: unsupported field type: %T", v)
+			}
+		}
+
 	case "DATETIME":
 		return func(field types.Field) (driver.Value, error) {
 			switch v := field.(type) {

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -183,7 +183,7 @@ func (d *DialectMySQL) GetFieldConverter(columnType string) FieldConverter {
 			switch v := field.(type) {
 			case *types.FieldMemberStringValue:
 				if !d.parseTime {
-					return v.Value, nil
+					return []byte(v.Value), nil
 				}
 				t, err := time.ParseInLocation("2006-01-02 15:04:05.999999999", v.Value, d.getLocation())
 				if err != nil {

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -260,6 +260,50 @@ func TestDialectMySQL_GetFieldConverter(t *testing.T) {
 		}
 	})
 
+	t.Run("DATETIME parseTime=false", func(t *testing.T) {
+		d := &DialectMySQL{
+			parseTime: false,
+		}
+		conv := d.GetFieldConverter("DATETIME")
+		v, err := conv(&types.FieldMemberStringValue{Value: "2006-01-02 15:04:05.999999999"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, ok := v.([]byte)
+		if !ok {
+			t.Fatalf("unexpected value: %v, want []byte", v)
+		}
+		if string(data) != "2006-01-02 15:04:05.999999999" {
+			t.Errorf("unexpected value: %v, want 2006-01-02 15:04:05.999999999", v)
+		}
+	})
+
+	t.Run("DATETIME parseTime=true", func(t *testing.T) {
+		d := &DialectMySQL{
+			parseTime: true,
+		}
+		conv := d.GetFieldConverter("DATETIME")
+		v, err := conv(&types.FieldMemberStringValue{Value: "2006-01-02 15:04:05.999999999"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v != time.Date(2006, 1, 2, 15, 4, 5, 999_999_999, time.UTC) {
+			t.Errorf("unexpected value: %v, want 2006-01-02 15:04:05.999999999", v)
+		}
+	})
+
+	t.Run("DATETIME NULL", func(t *testing.T) {
+		d := &DialectMySQL{}
+		conv := d.GetFieldConverter("DATETIME")
+		v, err := conv(&types.FieldMemberIsNull{Value: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v != nil {
+			t.Errorf("unexpected value: %v, want nil", v)
+		}
+	})
+
 	t.Run("FieldMemberLongValue", func(t *testing.T) {
 		d := &DialectMySQL{}
 		conv := d.GetFieldConverter("BIGINT")

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -260,6 +260,50 @@ func TestDialectMySQL_GetFieldConverter(t *testing.T) {
 		}
 	})
 
+	t.Run("DATE parseTime=false", func(t *testing.T) {
+		d := &DialectMySQL{
+			parseTime: false,
+		}
+		conv := d.GetFieldConverter("DATE")
+		v, err := conv(&types.FieldMemberStringValue{Value: "2006-01-02"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, ok := v.([]byte)
+		if !ok {
+			t.Fatalf("unexpected value: %v, want []byte", v)
+		}
+		if string(data) != "2006-01-02" {
+			t.Errorf("unexpected value: %v, want 2006-01-02", v)
+		}
+	})
+
+	t.Run("DATE parseTime=true", func(t *testing.T) {
+		d := &DialectMySQL{
+			parseTime: true,
+		}
+		conv := d.GetFieldConverter("DATE")
+		v, err := conv(&types.FieldMemberStringValue{Value: "2006-01-02"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v != time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC) {
+			t.Errorf("unexpected value: %v, want 2006-01-02", v)
+		}
+	})
+
+	t.Run("DATE NULL", func(t *testing.T) {
+		d := &DialectMySQL{}
+		conv := d.GetFieldConverter("DATE")
+		v, err := conv(&types.FieldMemberIsNull{Value: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v != nil {
+			t.Errorf("unexpected value: %v, want nil", v)
+		}
+	})
+
 	t.Run("DATETIME parseTime=false", func(t *testing.T) {
 		d := &DialectMySQL{
 			parseTime: false,


### PR DESCRIPTION
…ponding integration test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced MySQL integration test coverage for `DATE`, `DATETIME`, and `TIMESTAMP` data types.
	- Improved MySQL dialect support for parsing `DATE`, `DATETIME`, and `TIMESTAMP` fields with timezone handling.

- **Tests**
	- Added comprehensive test cases for `DATE` and `DATETIME` column type conversion, including handling of null values and different `parseTime` configurations.
	- Validated timestamp retrieval and timezone conversion for MySQL integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->